### PR TITLE
Modify end_tag_regex to allow named arrays

### DIFF
--- a/src/custom_tag_index/custom_tag_index.py
+++ b/src/custom_tag_index/custom_tag_index.py
@@ -3,7 +3,7 @@ import re
 
 attribute_regex = re.compile(r"\battributes\.(\w+)\b(?!\s*\()", re.I)
 end_tag_regex = re.compile(
-    r"thistag\.executionmode\s+(?:eq|is|==)\s+[\"']end[\"']", re.I
+    r"thistag(?:\.|\[[\"'])executionmode(?:[\"']])?\s+(?:eq|is|==)\s+[\"']end[\"']", re.I
 )
 alt_end_tag_regex = re.compile(r"<cfcase\s+value=\s*[\"']end[\"']\s*>")
 


### PR DESCRIPTION
When determining if a custom tag uses an end tag, the regex should also allow for the following:

thistag["executionmode"]
thistag['executionmode']

Currently, the regex only allows for thistag.executionmode to determine the end tag.

The proposed regex was tested with the following variations:

thistag.executionmode == "end"
thistag.executionmode == 'end'
thistag.executionmode eq "end"
thistag.executionmode eq 'end'
thistag.executionmode is "end"
thistag.executionmode is 'end'
thistag["executionmode"] == "end"
thistag["executionmode"] == 'end'
thistag["executionmode"] eq "end"
thistag["executionmode"] eq 'end'
thistag["executionmode"] is "end"
thistag["executionmode"] is 'end'
thistag['executionmode'] == "end"
thistag['executionmode'] == 'end'
thistag['executionmode'] eq "end"
thistag['executionmode'] eq 'end'
thistag['executionmode'] is "end"
thistag['executionmode'] is 'end'

Thank you!